### PR TITLE
Set up auto assign workflow

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,8 @@
+addReviewers: true
+addAssignees: false
+
+reviewers:
+  - megankj
+  - tjgoog
+
+numberOfReviewers: 1

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,11 @@
+name: Auto Assign
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: pull_request
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.1.1


### PR DESCRIPTION
This should assign a reviewer once you create a pull request.  Hopefully it picks Tim or I at random.  Maybe you can make a small change and test it out?